### PR TITLE
Add `extra` recipe for nightly releasae

### DIFF
--- a/custom-recipes/recipes/extra/meta.yaml
+++ b/custom-recipes/recipes/extra/meta.yaml
@@ -1,5 +1,6 @@
 {% set name = "EXtra" %}
-{% set version = "nightly" %}
+# {% set version = load_file_regex(load_file='__version__.py', regex_pattern="=\s*'([^']+)'") %}
+{% set version = "2023.1" %}
 
 package:
   name: {{ name|lower }}
@@ -8,6 +9,7 @@ package:
 source:
   git_url: https://github.com/European-XFEL/Extra
   git_rev: master
+  git_depth: 1
 
 build:
   noarch: python
@@ -18,11 +20,14 @@ requirements:
   host:
     - python >=3.9
     - pip
+  build:
+    - setuptools_scm
   run:
     - python >=3.9
-    - extra_data
-    - extra_geom
-    - karabo_bridge
+    - extra-data
+    - extra-geom
+    - karabo-bridge
+    - euxfel-bunch-pattern
 
 test:
   imports:
@@ -34,7 +39,7 @@ test:
 
 about:
   home: https://github.com/European-XFEL/EXtra
-  summary: European XFEL toolkit for research and analysis
+  summary: "European XFEL toolkit for research and analysis"
   license: BSD-3-Clause
 
 extra:

--- a/custom-recipes/recipes/extra/meta.yaml
+++ b/custom-recipes/recipes/extra/meta.yaml
@@ -24,7 +24,7 @@ requirements:
     - setuptools_scm
   run:
     - python >=3.9
-    - extra-data
+    - extra-data >=1.13
     - extra-geom
     - karabo-bridge
     - euxfel-bunch-pattern

--- a/custom-recipes/recipes/extra/meta.yaml
+++ b/custom-recipes/recipes/extra/meta.yaml
@@ -1,0 +1,43 @@
+{% set name = "EXtra" %}
+{% set version = "nightly" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  git_url: https://github.com/European-XFEL/Extra
+  git_rev: master
+
+build:
+  noarch: python
+  script: {{ PYTHON }} -m pip install . -vv
+  number: 0
+
+requirements:
+  host:
+    - python >=3.9
+    - pip
+  run:
+    - python >=3.9
+    - extra_data
+    - extra_geom
+    - karabo_bridge
+
+test:
+  imports:
+    - extra
+  commands:
+    - pip check
+  requires:
+    - pip
+
+about:
+  home: https://github.com/European-XFEL/EXtra
+  summary: European XFEL toolkit for research and analysis
+  license: BSD-3-Clause
+  license_file: PLEASE_ADD_LICENSE_FILE
+
+extra:
+  recipe-maintainers:
+    - AddYourGitHubIdHere

--- a/custom-recipes/recipes/extra/meta.yaml
+++ b/custom-recipes/recipes/extra/meta.yaml
@@ -36,8 +36,7 @@ about:
   home: https://github.com/European-XFEL/EXtra
   summary: European XFEL toolkit for research and analysis
   license: BSD-3-Clause
-  license_file: PLEASE_ADD_LICENSE_FILE
 
 extra:
   recipe-maintainers:
-    - AddYourGitHubIdHere
+    - Robert Rosca


### PR DESCRIPTION
Adds the recipe file for `extra`. The version is currently set to a fixed string `"2023.1"`, if https://github.com/European-XFEL/EXtra/pull/18 is merged then that can be replaced with the commented-out line above it to enable dynamically pulling the version out from a `__version__.py` file generated by setuptools-scm at build time.