### PR TITLE
Use boa recipe format instead of meta.yaml

### DIFF
--- a/custom-recipes/Makefile
+++ b/custom-recipes/Makefile
@@ -6,6 +6,7 @@ ARGS := --rm -it --workdir=/io \
 	-v $(HOME)/.ssh:/home/mambauser/.ssh \
 	-v $(CURDIR)/conda-bld:/opt/conda/conda-bld \
 	-v $(CURDIR):/io \
+	--shm-size 16gb \
 	ghcr.io/european-xfel/environments:main
 
 

--- a/custom-recipes/build.sh
+++ b/custom-recipes/build.sh
@@ -30,6 +30,7 @@ boa build \
   --skip-existing \
   --croot $tmp_shm \
   --output-folder ./conda-bld \
+  --target-platform linux-64 \
   $p
 
 conda index ./conda-bld

--- a/custom-recipes/build.sh
+++ b/custom-recipes/build.sh
@@ -3,16 +3,33 @@
 set -euo pipefail
 shopt -s inherit_errexit
 
+
+if [ $# -eq 0 ]; then
+  p="./recipes"
+elif [ $# -eq 1 ]; then
+  p="./recipes/$1"
+else
+  echo "Usage: $0 [package-name]"
+  exit 1
+fi
+
+cleanup_tmp_shm() {
+    if [ -d "$tmp_shm" ]; then
+        echo "Cleaning up temporary directory: $tmp_shm"
+        rm -rf "$tmp_shm"
+    fi
+}
+
+trap cleanup_tmp_shm EXIT
+
+tmp_shm=$(mktemp -d -p /dev/shm boa-XXXX)
+
 conda index ./conda-bld
 
-export CONDA_BLD_PATH="$PWD/conda-bld"
-
-conda mambabuild \
+boa build \
   --skip-existing \
-  --python 3.9 \
-  --numpy 1.23 \
-  --no-anaconda-upload \
-  -c nodefaults -c conda-forge -c $CONDA_BLD_PATH \
-  ./recipes
+  --croot $tmp_shm \
+  --output-folder ./conda-bld \
+  $p
 
 conda index ./conda-bld

--- a/custom-recipes/recipes/calibration-client/recipe.yaml
+++ b/custom-recipes/recipes/calibration-client/recipe.yaml
@@ -1,9 +1,10 @@
-{% set name = "calibration-client" %}
-{% set version = "11.0.0" %}
+context:
+  name: calibration-client
+  version: 11.0.0
 
 package:
-  name: {{ name|lower }}
-  version: {{ version }}
+  name: '{{ name|lower }}'
+  version: '{{ version }}'
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/calibration_client-{{ version }}.tar.gz
@@ -11,7 +12,7 @@ source:
 
 build:
   noarch: python
-  script: {{ PYTHON }} -m pip install . -vv
+  script: '{{ PYTHON }} -m pip install . -vv'
   number: 0
 
 requirements:
@@ -36,10 +37,11 @@ test:
 
 about:
   home: https://git.xfel.eu/gitlab/ITDM/calibration_client
-  summary: "Python Client for European XFEL Calibration Catalogue Web App available at https://in.xfel.eu/calibration"
+  summary: Python Client for European XFEL Calibration Catalogue Web App available at https://in.xfel.eu/calibration
   license: MIT
   license_file: LICENSE
 
 extra:
   recipe-maintainers:
     - RobertRosca
+

--- a/custom-recipes/recipes/cfelpyutils/recipe.yaml
+++ b/custom-recipes/recipes/cfelpyutils/recipe.yaml
@@ -1,22 +1,23 @@
-{% set name = "cfelpyutils" %}
-{% set version = "2.0.6" %}
+context:
+  name: cfelpyutils
+  version: 2.0.6
 
 package:
-  name: {{ name|lower }}
-  version: {{ version }}
+  name: '{{ name|lower }}'
+  version: '{{ version }}'
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/cfelpyutils-{{ version }}.tar.gz
   sha256: 218c3742388dec2cf781042dab4f4740c1132eb33d315b8360b848c1580e5231
 
 build:
-  script: {{ PYTHON }} -m pip install . -vv
+  script: '{{ PYTHON }} -m pip install . -vv'
   number: 0
 
 requirements:
   build:
-    - {{ compiler('cxx') }}
-    - {{ compiler('c') }}
+    - '{{ compiler("cxx") }}'
+    - '{{ compiler("c") }}'
   host:
     - python
     - numpy
@@ -27,8 +28,7 @@ requirements:
     - h5py >=2.9.0
     - mypy_extensions >=0.4.3
     - pandas >=1.1.5
-    - typing >=3.6.4  # [py<37]
-    - {{ pin_compatible('numpy') }}
+    - numpy
 
 test:
   imports:
@@ -40,10 +40,11 @@ test:
 
 about:
   home: https://gitlab.desy.de/cfel-sc-public/cfelpyutils
-  summary: "Utility functions and classes for CFEL software projects"
+  summary: Utility functions and classes for CFEL software projects
   license: GPL-3.0
   license_file: LICENSE
 
 extra:
   recipe-maintainers:
     - RobertRosca
+

--- a/custom-recipes/recipes/condat-gridconv/recipe.yaml
+++ b/custom-recipes/recipes/condat-gridconv/recipe.yaml
@@ -1,21 +1,22 @@
-{% set name = "condat-gridconv" %}
-{% set version = "latest" %}
+context:
+  name: condat-gridconv
+  version: latest
 
 package:
-  name: {{ name|lower }}
-  version: {{ version }}
+  name: '{{ name|lower }}'
+  version: '{{ version }}'
 
 source:
   url: https://github.com/European-XFEL/condat-gridconv/archive/{{ version }}.tar.gz
   sha256: 2cbdf516bde34b80f7be0a56cb3dee580cfc990d07ce9a46ca0eb6bd9cf18277
 
 build:
-  script: {{ PYTHON }} -m pip install . -vv
+  script: '{{ PYTHON }} -m pip install . -vv'
   number: 0
 
 requirements:
   build:
-    - {{ compiler('c') }}
+    - '{{ compiler("c") }}'
   host:
     - python
     - setuptools
@@ -41,3 +42,4 @@ about:
 extra:
   recipe-maintainers:
     - RobertRosca
+

--- a/custom-recipes/recipes/dioptas/recipe.yaml
+++ b/custom-recipes/recipes/dioptas/recipe.yaml
@@ -1,9 +1,10 @@
-{% set name = "dioptas" %}
-{% set version = "0.5.6" %}
+context:
+  name: dioptas
+  version: 0.5.6
 
 package:
-  name: {{ name|lower }}
-  version: {{ version }}
+  name: '{{ name|lower }}'
+  version: '{{ version }}'
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/dioptas-{{ version }}.tar.gz
@@ -12,16 +13,17 @@ source:
   #  - pyqt-requirement.patch
 
 build:
-  skip: true  # [py<37]
   entry_points:
     - dioptas = scripts:dioptas.main
     - dioptas_batch = scripts:dioptas_batch.main
-  # script: bash ./install.sh #{{ PYTHON }} -m pip install . -vv
+  # script: 'bash ./install.sh #{{ PYTHON }} -m pip install . -vv'
   number: 0
 
+  skip:
+    - py<37
 requirements:
   build:
-    - {{ compiler('c') }}
+    - '{{ compiler("c") }}'
   host:
     - python
     - setuptools >=45
@@ -64,7 +66,7 @@ test:
 
 about:
   home: https://github.com/Dioptas/Dioptas
-  summary: "GUI program for reduction and exploration of 2D X-ray diffraction data"
+  summary: GUI program for reduction and exploration of 2D X-ray diffraction data
   dev_url: https://github.com/dioptas/dioptas
   license: GPL-3.0
   license_file: license.txt
@@ -72,3 +74,4 @@ about:
 extra:
   recipe-maintainers:
     - RobertRosca
+

--- a/custom-recipes/recipes/envmodules/recipe.yaml
+++ b/custom-recipes/recipes/envmodules/recipe.yaml
@@ -1,9 +1,10 @@
-{% set name = "envmodules" %}
-{% set version = "0.1" %}
+context:
+  name: envmodules
+  version: '0.1'
 
 package:
-  name: {{ name|lower }}
-  version: {{ version }}
+  name: '{{ name|lower }}'
+  version: '{{ version }}'
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/envmodules-{{ version }}.tar.gz
@@ -11,7 +12,7 @@ source:
 
 build:
   noarch: python
-  script: {{ PYTHON }} -m pip install . -vv
+  script: '{{ PYTHON }} -m pip install . -vv'
   number: 0
 
 requirements:
@@ -32,7 +33,7 @@ test:
 
 about:
   home: https://github.com/European-XFEL/envmodules
-  summary: "Python wrapper around environment modules ('module load')"
+  summary: Python wrapper around environment modules ('module load')
   license: BSD-3-Clause
   license_file: LICENSE
 
@@ -40,3 +41,4 @@ extra:
   notes: "'flit-core' added manually"
   recipe-maintainers:
     - RobertRosca
+

--- a/custom-recipes/recipes/euxfel-bunch-pattern/recipe.yaml
+++ b/custom-recipes/recipes/euxfel-bunch-pattern/recipe.yaml
@@ -1,9 +1,10 @@
-{% set name = "euxfel-bunch-pattern" %}
-{% set version = "0.6" %}
+context:
+  name: euxfel-bunch-pattern
+  version: '0.6'
 
 package:
-  name: {{ name|lower }}
-  version: {{ version }}
+  name: '{{ name|lower }}'
+  version: '{{ version }}'
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/euxfel_bunch_pattern-{{ version }}.tar.gz
@@ -11,7 +12,7 @@ source:
 
 build:
   noarch: python
-  script: {{ PYTHON }} -m pip install . -vv
+  script: '{{ PYTHON }} -m pip install . -vv'
   number: 0
 
 requirements:
@@ -32,10 +33,11 @@ test:
 
 about:
   home: https://git.xfel.eu/gitlab/karaboDevices/euxfel_bunch_pattern
-  summary: "Decoding EuXFEL bunch pattern tables"
+  summary: Decoding EuXFEL bunch pattern tables
   license: ''
     # license_file: TODO: PLEASE_ADD_LICENSE_FILE
 
 extra:
   recipe-maintainers:
     - RobertRosca
+

--- a/custom-recipes/recipes/extra-data/recipe.yaml
+++ b/custom-recipes/recipes/extra-data/recipe.yaml
@@ -1,9 +1,10 @@
-{% set name = "extra-data" %}
-{% set version = "1.13.0" %}
+context:
+  name: extra-data
+  version: 1.13.0
 
 package:
-  name: {{ name|lower }}
-  version: {{ version }}
+  name: '{{ name|lower }}'
+  version: '{{ version }}'
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/EXtra-data-{{ version }}.tar.gz
@@ -17,7 +18,7 @@ build:
     - extra-data-make-virtual-cxi = extra_data.cli.make_virtual_cxi:main
     - extra-data-locality = extra_data.locality:main
   noarch: python
-  script: {{ PYTHON }} -m pip install . -vv
+  script: '{{ PYTHON }} -m pip install . -vv'
   number: 1
 
 requirements:
@@ -31,7 +32,7 @@ requirements:
     - pandas
     - xarray
     - matplotlib
-    - dask[array]
+    - sel(array): dask[array]
 
 test:
   imports:
@@ -48,7 +49,7 @@ test:
 
 about:
   home: https://pypi.org/project/EXtra-data/
-  summary: "Tools to read and analyse data from European XFEL"
+  summary: Tools to read and analyse data from European XFEL
   dev_url: https://github.com/European-XFEL/EXtra-data
   license: BSD-3-Clause
   license_file: LICENSE
@@ -56,3 +57,4 @@ about:
 extra:
   recipe-maintainers:
     - RobertRosca
+

--- a/custom-recipes/recipes/extra-geom/recipe.yaml
+++ b/custom-recipes/recipes/extra-geom/recipe.yaml
@@ -1,9 +1,10 @@
-{% set name = "extra-geom" %}
-{% set version = "1.9.0" %}
+context:
+  name: extra-geom
+  version: 1.9.0
 
 package:
-  name: {{ name|lower }}
-  version: {{ version }}
+  name: '{{ name|lower }}'
+  version: '{{ version }}'
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/EXtra-geom-{{ version }}.tar.gz
@@ -11,7 +12,7 @@ source:
 
 build:
   noarch: python
-  script: {{ PYTHON }} -m pip install . -vv
+  script: '{{ PYTHON }} -m pip install . -vv'
   number: 0
 
 requirements:
@@ -35,10 +36,11 @@ test:
 
 about:
   home: https://github.com/European-XFEL/EXtra-geom
-  summary: "Tools to work with EuXFEL detector geometry and assemble detector images"
+  summary: Tools to work with EuXFEL detector geometry and assemble detector images
   license: BSD-3-Clause
   license_file: LICENSE
 
 extra:
   recipe-maintainers:
     - RobertRosca
+

--- a/custom-recipes/recipes/extra-hed/recipe.yaml
+++ b/custom-recipes/recipes/extra-hed/recipe.yaml
@@ -1,9 +1,10 @@
-{% set name = "EXtra-HED" %}
-{% set version = "0.1.0" %}
+context:
+  name: EXtra-HED
+  version: 0.1.0
 
 package:
-  name: {{ name|lower }}
-  version: {{ version }}
+  name: '{{ name|lower }}'
+  version: '{{ version }}'
 
 source:
   # path: /gpfs/exfel/sw/software/xfel_anaconda3/mambaforge-22.9/conda-recipes/src/EXtra-HED
@@ -12,7 +13,7 @@ source:
 
 build:
   noarch: python
-  script: {{ PYTHON }} -m pip install . -vv
+  script: '{{ PYTHON }} -m pip install . -vv'
   number: 0
 
 requirements:
@@ -37,11 +38,12 @@ test:
     - pip
 
 about:
-  summary: "Analysis toolbox for the HED instrument at EuXFEL."
+  summary: Analysis toolbox for the HED instrument at EuXFEL.
   license: BSD-3-Clause
   dev_url: https://git.xfel.eu:10022/tmichela/EXtra-HED.git
 
 extra:
-  notes: "Invalid license removed manually"
+  notes: Invalid license removed manually
   recipe-maintainers:
     - RobertRosca
+

--- a/custom-recipes/recipes/findxfel/recipe.yaml
+++ b/custom-recipes/recipes/findxfel/recipe.yaml
@@ -1,20 +1,20 @@
-{% set name = "findxfel" %}
-{% set version = "0.1.1" %}
+context:
+  name: findxfel
+  version: 0.1.1
 
 package:
-  name: {{ name|lower }}
-  version: {{ version }}
+  name: '{{ name|lower }}'
+  version: '{{ version }}'
 
 source:
-  # path: /gpfs/exfel/sw/software/xfel_anaconda3/mambaforge-22.9/conda-recipes/src/findxfel
-  git_url: git+ssh://git.xfel.eu/dataAnalysis/findxfel
-  depth: 1
+  git_url: ssh://git.xfel.eu:10022/dataAnalysis/findxfel.git
+  git_depth: 1
 
 build:
   entry_points:
     - findxfel = findxfel:main
   noarch: python
-  script: {{ PYTHON }} -m pip install . -vv
+  script: '{{ PYTHON }} -m pip install . -vv'
   number: 0
 
 requirements:
@@ -36,12 +36,12 @@ test:
 
 about:
   home: https://git.xfel.eu/gitlab/dataAnalysis/findxfel
-  summary: "Find an EuXFEL proposal/run directory on Maxwell"
+  summary: Find an EuXFEL proposal/run directory on Maxwell
   license: BSD-3-Clause
-  license_file:
-    - LICENSE
+  license_file: LICENSE
 
 extra:
   notes: "'flit-core' added manually"
   recipe-maintainers:
     - RobertRosca
+

--- a/custom-recipes/recipes/hdf5-vds-check/recipe.yaml
+++ b/custom-recipes/recipes/hdf5-vds-check/recipe.yaml
@@ -1,9 +1,10 @@
-{% set name = "hdf5-vds-check" %}
-{% set version = "1.0" %}
+context:
+  name: hdf5-vds-check
+  version: '1.0'
 
 package:
-  name: {{ name|lower }}
-  version: {{ version }}
+  name: '{{ name|lower }}'
+  version: '{{ version }}'
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/hdf5_vds_check-{{ version }}.tar.gz
@@ -13,7 +14,7 @@ build:
   entry_points:
     - hdf5-vds-check = hdf5_vds_check:main
   noarch: python
-  script: {{ PYTHON }} -m pip install . -vv
+  script: '{{ PYTHON }} -m pip install . -vv'
   number: 0
 
 requirements:
@@ -36,7 +37,7 @@ test:
 
 about:
   home: https://github.com/European-XFEL/hdf5-vds-check
-  summary: "Check access to the source files of virtual datasets"
+  summary: Check access to the source files of virtual datasets
   license: BSD-3-Clause
   license_file: LICENSE
 
@@ -44,3 +45,4 @@ extra:
   notes: "'flit' added manually"
   recipe-maintainers:
     - RobertRosca
+

--- a/custom-recipes/recipes/htmlgen/recipe.yaml
+++ b/custom-recipes/recipes/htmlgen/recipe.yaml
@@ -1,9 +1,10 @@
-{% set name = "htmlgen" %}
-{% set version = "2.0.0" %}
+context:
+  name: htmlgen
+  version: 2.0.0
 
 package:
-  name: {{ name|lower }}
-  version: {{ version }}
+  name: '{{ name|lower }}'
+  version: '{{ version }}'
 
 source:
   url: https://github.com/srittau/python-htmlgen/archive/v{{ version }}.tar.gz
@@ -11,7 +12,7 @@ source:
 
 build:
   noarch: python
-  script: {{ PYTHON }} -m pip install . -vv
+  script: '{{ PYTHON }} -m pip install . -vv'
   number: 0
 
 requirements:
@@ -33,9 +34,9 @@ test:
 about:
   home: https://github.com/srittau/python-htmlgen
   license: MIT
-  license_file:
-    - LICENSE
+  license_file: LICENSE
 
 extra:
   recipe-maintainers:
     - RobertRosca
+

--- a/custom-recipes/recipes/karabo-bridge-recorder/recipe.yaml
+++ b/custom-recipes/recipes/karabo-bridge-recorder/recipe.yaml
@@ -1,9 +1,10 @@
-{% set name = "karabo_bridge_recorder" %}
-{% set version = "0.2" %}
+context:
+  name: karabo_bridge_recorder
+  version: '0.2'
 
 package:
-  name: {{ name|lower }}
-  version: {{ version }}
+  name: '{{ name|lower }}'
+  version: '{{ version }}'
 
 source:
   # path: /gpfs/exfel/sw/software/xfel_anaconda3/mambaforge-22.9/conda-recipes/src/karabo-bridge-recorder
@@ -15,7 +16,7 @@ build:
     - karabo-bridge-record = karabo_bridge_recorder.record:main
     - karabo-bridge-replay = karabo_bridge_recorder.replay:main
   noarch: python
-  script: {{ PYTHON }} -m pip install . -vv
+  script: '{{ PYTHON }} -m pip install . -vv'
   number: 0
 
 requirements:
@@ -38,7 +39,7 @@ test:
     - pip
 
 about:
-  summary: "Record and play back data streams from Karabo bridge"
+  summary: Record and play back data streams from Karabo bridge
   license: Other
   dev_url: https://git.xfel.eu:10022/tmichela/EXtra-HED.git
 
@@ -46,3 +47,4 @@ extra:
   notes: "'flit-core' added manually"
   recipe-maintainers:
     - RobertRosca
+

--- a/custom-recipes/recipes/karabo-bridge/recipe.yaml
+++ b/custom-recipes/recipes/karabo-bridge/recipe.yaml
@@ -1,9 +1,10 @@
-{% set name = "karabo-bridge" %}
-{% set version = "0.6.2" %}
+context:
+  name: karabo-bridge
+  version: 0.6.2
 
 package:
-  name: {{ name|lower }}
-  version: {{ version }}
+  name: '{{ name|lower }}'
+  version: '{{ version }}'
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/karabo_bridge-{{ version }}.tar.gz
@@ -15,7 +16,7 @@ build:
     - karabo-bridge-monitor=karabo_bridge.cli.monitor:main
     - karabo-bridge-server-sim=karabo_bridge.cli.simulation:main
   noarch: python
-  script: {{ PYTHON }} -m pip install . -vv
+  script: '{{ PYTHON }} -m pip install . -vv'
   number: 0
 
 requirements:
@@ -43,10 +44,11 @@ test:
 
 about:
   home: https://github.com/European-XFEL/karabo-bridge-py
-  summary: "Python 3 tools to request data from the Karabo controlsystem."
+  summary: Python 3 tools to request data from the Karabo controlsystem.
   license: BSD-3-Clause
   license_file: LICENSE
 
 extra:
   recipe-maintainers:
     - RobertRosca
+

--- a/custom-recipes/recipes/matplotlib-scalebar/recipe.yaml
+++ b/custom-recipes/recipes/matplotlib-scalebar/recipe.yaml
@@ -1,9 +1,10 @@
-{% set name = "matplotlib-scalebar" %}
-{% set version = "0.8.1" %}
+context:
+  name: matplotlib-scalebar
+  version: 0.8.1
 
 package:
-  name: {{ name|lower }}
-  version: {{ version }}
+  name: '{{ name|lower }}'
+  version: '{{ version }}'
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/matplotlib-scalebar-{{ version }}.tar.gz
@@ -11,7 +12,7 @@ source:
 
 build:
   noarch: python
-  script: {{ PYTHON }} -m pip install . -vv
+  script: '{{ PYTHON }} -m pip install . -vv'
   number: 0
 
 requirements:
@@ -32,11 +33,11 @@ test:
 
 about:
   home: https://github.com/ppinard/matplotlib-scalebar
-  summary: "Artist for matplotlib to display a scale bar"
+  summary: Artist for matplotlib to display a scale bar
   license: BSD-2-Clause
-  license_file:
-    - LICENSE
+  license_file: LICENSE
 
 extra:
   recipe-maintainers:
     - RobertRosca
+

--- a/custom-recipes/recipes/metadata-client/recipe.yaml
+++ b/custom-recipes/recipes/metadata-client/recipe.yaml
@@ -1,9 +1,10 @@
-{% set name = "metadata-client" %}
-{% set version = "3.9.0" %}
+context:
+  name: metadata-client
+  version: 3.9.0
 
 package:
-  name: {{ name|lower }}
-  version: {{ version }}
+  name: '{{ name|lower }}'
+  version: '{{ version }}'
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/metadata_client-{{ version }}.tar.gz
@@ -11,7 +12,7 @@ source:
 
 build:
   noarch: python
-  script: {{ PYTHON }} -m pip install . -vv
+  script: '{{ PYTHON }} -m pip install . -vv'
   number: 0
 
 requirements:
@@ -36,10 +37,11 @@ test:
 
 about:
   home: https://git.xfel.eu/gitlab/ITDM/metadata_client
-  summary: "Python Client for European XFEL Metadata Catalogue Web App available at https://in.xfel.eu/metadata"
+  summary: Python Client for European XFEL Metadata Catalogue Web App available at https://in.xfel.eu/metadata
   license: MIT
   license_file: LICENSE
 
 extra:
   recipe-maintainers:
     - RobertRosca
+

--- a/custom-recipes/recipes/metropc/recipe.yaml
+++ b/custom-recipes/recipes/metropc/recipe.yaml
@@ -1,9 +1,10 @@
-{% set name = "metropc" %}
-{% set version = "1.4.1" %}
+context:
+  name: metropc
+  version: 1.4.1
 
 package:
-  name: {{ name|lower }}
-  version: {{ version }}
+  name: '{{ name|lower }}'
+  version: '{{ version }}'
 
 source:
   # path: /gpfs/exfel/sw/software/xfel_anaconda3/mambaforge-22.9/conda-recipes/src/metropc
@@ -12,7 +13,7 @@ source:
 
 build:
   noarch: python
-  script: {{ PYTHON }} -m pip install . -vv
+  script: '{{ PYTHON }} -m pip install . -vv'
   number: 0
 
 requirements:
@@ -39,10 +40,11 @@ test:
 
 about:
   summary: Programmable event processing framework
-  license: "MIT & Apache-2.0"
+  license: MIT & Apache-2.0
   dev_url: https://git.xfel.eu/karaboDevices/metropc.git
 
 extra:
-  notes: "Invalid license file removed manually"
+  notes: Invalid license file removed manually
   recipe-maintainers:
     - RobertRosca
+

--- a/custom-recipes/recipes/oauth2-xfel-client/recipe.yaml
+++ b/custom-recipes/recipes/oauth2-xfel-client/recipe.yaml
@@ -1,9 +1,10 @@
-{% set name = "oauth2-xfel-client" %}
-{% set version = "6.1.0" %}
+context:
+  name: oauth2-xfel-client
+  version: 6.1.0
 
 package:
-  name: {{ name|lower }}
-  version: {{ version }}
+  name: '{{ name|lower }}'
+  version: '{{ version }}'
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/oauth2_xfel_client-{{ version }}.tar.gz
@@ -11,7 +12,7 @@ source:
 
 build:
   noarch: python
-  script: {{ PYTHON }} -m pip install . -vv
+  script: '{{ PYTHON }} -m pip install . -vv'
   number: 0
 
 requirements:
@@ -35,10 +36,11 @@ test:
 
 about:
   home: https://git.xfel.eu/gitlab/ITDM/oauth2_xfel_client
-  summary: "Python OAUTH 2.0 generic Client used for Backend Application strategy authentication on European XFEL Web Applications"
+  summary: Python OAUTH 2.0 generic Client used for Backend Application strategy authentication on European XFEL Web Applications
   license: MIT
   license_file: LICENSE
 
 extra:
   recipe-maintainers:
     - RobertRosca
+

--- a/custom-recipes/recipes/pasha/recipe.yaml
+++ b/custom-recipes/recipes/pasha/recipe.yaml
@@ -1,9 +1,10 @@
-{% set name = "pasha" %}
-{% set version = "0.1.1" %}
+context:
+  name: pasha
+  version: 0.1.1
 
 package:
-  name: {{ name|lower }}
-  version: {{ version }}
+  name: '{{ name|lower }}'
+  version: '{{ version }}'
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/pasha-{{ version }}.tar.gz
@@ -11,7 +12,7 @@ source:
 
 build:
   noarch: python
-  script: {{ PYTHON }} -m pip install . -vv
+  script: '{{ PYTHON }} -m pip install . -vv'
   number: 0
 
 requirements:
@@ -32,10 +33,11 @@ test:
 
 about:
   home: https://github.com/European-XFEL/pasha
-  summary: "Tools to parallelize operations on large data sets using shared memory with zero copies."
+  summary: Tools to parallelize operations on large data sets using shared memory with zero copies.
   license: BSD-3-Clause
   license_file: LICENSE
 
 extra:
   recipe-maintainers:
     - RobertRosca
+

--- a/custom-recipes/recipes/princess/recipe.yaml
+++ b/custom-recipes/recipes/princess/recipe.yaml
@@ -1,9 +1,10 @@
-{% set name = "princess" %}
-{% set version = "0.6" %}
+context:
+  name: princess
+  version: '0.6'
 
 package:
-  name: {{ name|lower }}
-  version: {{ version }}
+  name: '{{ name|lower }}'
+  version: '{{ version }}'
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/princess-{{ version }}.tar.gz
@@ -11,7 +12,7 @@ source:
 
 build:
   noarch: python
-  script: {{ PYTHON }} -m pip install . -vv
+  script: '{{ PYTHON }} -m pip install . -vv'
   number: 0
 
 requirements:
@@ -36,7 +37,7 @@ test:
 
 about:
   home: https://pypi.org/project/princess/
-  summary: "Please Run IPython Notebook in the Current Environment with Stdout & Stderr"
+  summary: Please Run IPython Notebook in the Current Environment with Stdout & Stderr
   dev_url: https://github.com/European-XFEL/princess
   license: BSD-3-Clause
   license_file: LICENSE
@@ -45,3 +46,4 @@ extra:
   notes: "'flit-core' added manually"
   recipe-maintainers:
     - RobertRosca
+

--- a/custom-recipes/recipes/sharedmem/recipe.yaml
+++ b/custom-recipes/recipes/sharedmem/recipe.yaml
@@ -1,9 +1,10 @@
-{% set name = "sharedmem" %}
-{% set version = "0.3.8" %}
+context:
+  name: sharedmem
+  version: 0.3.8
 
 package:
-  name: {{ name|lower }}
-  version: {{ version }}
+  name: '{{ name|lower }}'
+  version: '{{ version }}'
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/sharedmem-{{ version }}.tar.gz
@@ -11,7 +12,7 @@ source:
 
 build:
   noarch: python
-  script: {{ PYTHON }} -m pip install . -vv
+  script: '{{ PYTHON }} -m pip install . -vv'
   number: 0
 
 requirements:
@@ -32,10 +33,11 @@ test:
 
 about:
   home: http://github.com/rainwoodman/sharedmem
-  summary: "Dispatch your trivially parallizable jobs with sharedmem."
+  summary: Dispatch your trivially parallizable jobs with sharedmem.
   license: GPL-3.0
   license_file: LICENSE
 
 extra:
   recipe-maintainers:
     - RobertRosca
+


### PR DESCRIPTION
Converted normal conda `meta.yaml` to Boa `recipe.yaml`, not much change.

Set the build script to use `/dev/shm/boa-XXX` as the croot for temporary build files as GPFS was seriously slowing down builds.

Updated build script a bit so that running it will build everything, or you can pass the name of a single package.