### PR TITLE
Update karabo-bridge recipe for 0.7

### DIFF
--- a/custom-recipes/recipes/karabo-bridge/recipe.yaml
+++ b/custom-recipes/recipes/karabo-bridge/recipe.yaml
@@ -1,14 +1,13 @@
 context:
   name: karabo-bridge
-  version: 0.6.2
-
+  version: 0.7.0
 package:
   name: '{{ name|lower }}'
   version: '{{ version }}'
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/karabo_bridge-{{ version }}.tar.gz
-  sha256: 97d6c755a765708f2c25679d652b9b585fc57800f97a09b7a27211f9ba99c40b
+  sha256: cec6fbc2aa8de9dcabc1590029d24787fbe5b6a1760242f76f7d5f5781954223
 
 build:
   entry_points:

--- a/environments/202302/environment.lock.yml
+++ b/environments/202302/environment.lock.yml
@@ -1,9 +1,11 @@
 name: '202302'
 channels:
-  - nodefaults
-  - /gpfs/exfel/sw/software/euxfel-environment-management/custom-recipes/conda-bld
-  - conda-forge
+  - file:///gpfs/exfel/sw/software/euxfel-environment-management/custom-recipes/conda-bld
+  - file://gpfs/exfel/sw/software/euxfel-environment-management/custom-recipes/conda-bld
   - pytorch
+  - file://gpfs/exfel/sw/software/mambaforge/22.11/conda-bld
+  - nodefaults
+  - conda-forge
 dependencies:
   - _libgcc_mutex=0.1
   - _openmp_mutex=4.5
@@ -108,6 +110,7 @@ dependencies:
   - extra-geom=1.9.0
   - extra-hed=0.1.0
   - fabio=2023.4.1
+  - fast-histogram=0.11
   - ffmpeg=6.0.0
   - fftw=3.3.10
   - filelock=3.12.4
@@ -202,7 +205,7 @@ dependencies:
   - jupyterlab_widgets=1.1.0
   - jxrlib=1.1
   - kafka-python=2.0.2
-  - karabo-bridge=0.6.2
+  - karabo-bridge=0.7.0
   - karabo_bridge_recorder=0.2
   - keyring=24.2.0
   - keyutils=1.6.1
@@ -365,7 +368,7 @@ dependencies:
   - opencv=4.8.0
   - openh264=2.3.1
   - openjpeg=2.5.0
-  - openssl=3.1.2
+  - openssl=3.1.3
   - orc=1.9.0
   - orjson=3.9.2
   - p11-kit=0.24.1
@@ -583,5 +586,5 @@ dependencies:
   - zstd=1.5.2
   - pip:
       - da-utils==0.1.0
-      - euxfel-extra==2023.2.81+3a5708e
+      - euxfel-extra==2023.2.89+f4829c4
 prefix: /gpfs/exfel/sw/software/mambaforge/22.11/envs/202302


### PR DESCRIPTION
Adds Qt integration

I haven't added QtPy as a dependency since it's optional, but we should ensure it's installed in our general Python environment.