### PR TITLE
add 'no-pip-install' recipe

### DIFF
--- a/custom-recipes/recipes/no-pip-install/EXTERNALLY-MANAGED
+++ b/custom-recipes/recipes/no-pip-install/EXTERNALLY-MANAGED
@@ -1,0 +1,3 @@
+[externally-managed]
+Error=This is a pure conda environment, packages should not be installed into
+  it directly via pip.

--- a/custom-recipes/recipes/no-pip-install/README.md
+++ b/custom-recipes/recipes/no-pip-install/README.md
@@ -1,0 +1,5 @@
+# No Pip Install
+
+This 'package' use [PEP 668](https://peps.python.org/pep-0668/) to mark a conda environment it is installed into as 'externally managed', disallowing `pip install` commands from being run in the environment.
+
+It should be included in our per-cycle conda environments to prevent the environments from becoming difficult to maintain and track due to changes made by pip.

--- a/custom-recipes/recipes/no-pip-install/recipe.yaml
+++ b/custom-recipes/recipes/no-pip-install/recipe.yaml
@@ -19,6 +19,10 @@ requirements:
     - python >=3
     - pip >=23.0
 
+test:
+  commands:
+    - cat $STDLIB_DIR/EXTERNALLY-MANAGED
+
 about:
   license: GPL-3.0
 

--- a/custom-recipes/recipes/no-pip-install/recipe.yaml
+++ b/custom-recipes/recipes/no-pip-install/recipe.yaml
@@ -1,0 +1,28 @@
+context:
+  name: no-pip-install
+  version: 0.1.0
+
+package:
+  name: '{{ name|lower }}'
+  version: '{{ version }}'
+
+source:
+  path: .
+
+build:
+  script: "cp ./EXTERNALLY-MANAGED ${SP_DIR}/../."
+
+requirements:
+  host:
+    - python >=3
+  run:
+    - python >=3
+    - pip >=23.0
+
+about:
+  license: GPL-3.0
+
+extra:
+  recipe-maintainers:
+    - RobertRosca
+


### PR DESCRIPTION
Slight abomination of a 'package'.

When installed it adds an `EXTERNALLY-MANAGED` ([PEP 668](https://peps.python.org/pep-0668/)) file to the python stdlib directory, preventing direct `pip install` commands into the environment.

Behaviour is:

```shell
(tmp) [roscar@arch-desktop custom-recipes]$ mamba install -y no-pip-install -c ./conda-bld

...

(tmp) [roscar@arch-desktop custom-recipes]$ pip install numpy

error: externally-managed-environment

× This environment is externally managed
╰─> This is a pure conda environment, packages should not be installed into
    it directly via pip.

note: If you believe this is a mistake, please contact your Python installation or OS distribution provider. You can override this, at the risk of breaking your Python installation or OS, by passing --break-system-packages.
hint: See PEP 668 for the detailed specification.

(tmp) [roscar@arch-desktop custom-recipes]$ mamba install numpy

# works as expected
```

It'll prevent (well, warn, since you can force the install anyway) us from pip installing things into the environment accidentally, and could help with the occasional... odd... packages which internally run pip install to 'help'  simplify their use/setup.