### PR TITLE
Add Damnit and Related Packages

### DIFF
--- a/custom-recipes/recipes/damnit/recipe.yaml
+++ b/custom-recipes/recipes/damnit/recipe.yaml
@@ -1,0 +1,46 @@
+context:
+  name: damnit
+  version: '0.1'
+
+package:
+  name: '{{ name|lower }}'
+  version: '{{ version }}'
+
+source:
+  git_url: https://github.com/European-XFEL/damnit
+  git_tag: '{{ branch }}'
+
+build:
+  noarch: python
+  script: '{{ PYTHON }} -m pip install . -vv'
+  number: 0
+
+requirements:
+  host:
+    - python >=3.6
+    - flit-core >=3.2,<4
+    - pip
+  run:
+    - python >=3.9
+    - h5netcdf
+    - h5py
+    - pandas
+    - xarray
+
+test:
+  imports:
+    - damnit
+  commands:
+    - pip check
+  requires:
+    - pip
+
+about:
+  summary: The Data And Metadata iNspection Interactive Thing
+  license: BSD-3-Clause
+  license_file: LICENSE
+
+extra:
+  recipe-maintainers:
+    - RobertRosca
+

--- a/custom-recipes/recipes/damnit/recipe.yaml
+++ b/custom-recipes/recipes/damnit/recipe.yaml
@@ -1,10 +1,11 @@
 context:
   name: damnit
   version: '0.1'
+  branch: 'master'
 
 package:
   name: '{{ name|lower }}'
-  version: '{{ version }}'
+  version: '{{ version }}+{{ branch }}'
 
 source:
   git_url: https://github.com/European-XFEL/damnit


### PR DESCRIPTION
Adds recipes for damnit and mpl-pan-zoom.

In damnit's `pyproject.toml` QScintilla is pinned to `2.13` (`"QScintilla==2.13"`), I want to pin this to `2.13.*` instead, but that makes `pip check` fail as the version specified in `pyproject.toml` and installed do not match. There's a patch to fix this in the `pyproject.toml` file.

This change should also be done on damnit directly, but the patch should remain so that it's possible to build other versions/branches which have not had the version change made yet.