### PR TITLE
Update EXtra-data to 1.21

### DIFF
--- a/custom-recipes/recipes/extra-data/recipe.yaml
+++ b/custom-recipes/recipes/extra-data/recipe.yaml
@@ -1,6 +1,6 @@
 context:
   name: extra-data
-  version: 1.20.0
+  version: 1.21.0
 
 package:
   name: '{{ name|lower }}'
@@ -8,7 +8,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/extra_data-{{ version }}.tar.gz
-  sha256: 943eabbe9ad4b266c2dfe24c10ac0760df8ebf1e8899c56a1fb3cc2a6121c207
+  sha256: 4e246cb0842ca11ac9ca066d2266e8a0f00714560e06797e58d020c6b0d50ef2
 
 build:
   entry_points:
@@ -35,6 +35,7 @@ requirements:
     - xarray
     - matplotlib
     - pyyaml
+    - zlib-into
     - sel(array): dask[array]
 
 test:

--- a/custom-recipes/recipes/zlib-into/recipe.yaml
+++ b/custom-recipes/recipes/zlib-into/recipe.yaml
@@ -1,0 +1,42 @@
+context:
+  name: zlib-into
+  version: '0.2'
+
+package:
+  name: '{{ name|lower }}'
+  version: '{{ version }}'
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/zlib_into-{{ version }}.tar.gz
+  sha256: 65fb4bd3f268caf0c97fd102b71cd6148436590c46fbf321323e818306248e59
+
+build:
+  script: '{{ PYTHON }} -m pip install . -vv --no-build-isolation'
+  number: 0
+
+requirements:
+  build:
+    - '{{ compiler("c") }}'
+  host:
+    - python
+    - setuptools
+    - pip
+    - zlib
+  run:
+    - python
+    - zlib
+
+test:
+  imports:
+    - zlib_into
+
+about:
+  home: https://git.xfel.eu/dataAnalysis/zlib_into
+  summary: Compress & decompress data into preallocated buffers
+  license: MPL-2.0
+  license_file: LICENSE.md
+
+extra:
+  recipe-maintainers:
+    - RobertRosca
+

--- a/environments/202501/environment.lock.yml
+++ b/environments/202501/environment.lock.yml
@@ -132,7 +132,7 @@ dependencies:
   - exceptiongroup=1.2.2
   - executing=2.1.0
   - expat=2.6.4
-  - extra-data=1.20.0
+  - extra-data=1.21.0
   - extra-geom=1.14.0
   - extra-hed=0.1.0
   - fabio=2024.9.0
@@ -724,10 +724,11 @@ dependencies:
   - zict=3.0.0
   - zipp=3.21.0
   - zlib=1.3.1
+  - zlib-into=0.2
   - zlib-ng=2.0.7
   - zstandard=0.23.0
   - zstd=1.5.6
   - zulip=0.9.0
   - pip:
-      - euxfel-extra==2024.2.95+4bb8482
+      - euxfel-extra==2024.2.105+5010fab
 prefix: /gpfs/exfel/sw/software/mambaforge/22.11/envs/202501


### PR DESCRIPTION
Including a new recipe for zlib-into, which is a new package to help with the parallel decompression.

I've already updated the environment, so I'll merge this.