### PR TITLE
Add hhg-studio application

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ site/
 *~
 
 environments/*/julia-exfel-sysimage.so
+applications/hhg-studio/hhg-studio.sif

--- a/applications/hhg-studio/Dockerfile
+++ b/applications/hhg-studio/Dockerfile
@@ -1,0 +1,52 @@
+# Base image with workdir and apt (update/install) caching
+FROM ubuntu AS base
+
+WORKDIR /opt/hhg-studio
+
+RUN <<EOT
+rm -f /etc/apt/apt.conf.d/docker-clean
+echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache
+EOT
+
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+  --mount=type=cache,target=/var/lib/apt,sharing=locked \
+  apt update
+
+
+# Stage for pulling the hhg-studio snap package and
+# extracting the squashfs root
+FROM base AS snap
+
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+  --mount=type=cache,target=/var/lib/apt,sharing=locked \
+  apt update && apt install --no-install-recommends -y snapd squashfs-tools
+
+RUN snap download hhg-studio
+
+RUN unsquashfs hhg-studio_*.snap
+
+
+FROM base
+
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+  --mount=type=cache,target=/var/lib/apt,sharing=locked \
+  apt update && apt install -y --no-install-recommends qtbase5-dev libpng-dev libglib2.0-dev
+
+COPY --from=snap /opt/hhg-studio/squashfs-root ./squashfs-root
+
+# Define environment vars used by snap (launch.sh script)
+#ENV WAYLAND_DISABLE=1
+#ENV QT_DEBUG_PLUGINS=1
+ENV SNAP_ARCH=amd64
+ENV RUNTIME=/opt/hhg-studio/squashfs-root
+ENV SNAP=/opt/hhg-studio/squashfs-root
+ENV SNAP_USER_COMMON=/tmp/hhg-studio/common
+ENV SNAP_USER_DATA=/tmp/hhg-studio/home
+
+RUN <<EOT
+cp /opt/hhg-studio/squashfs-root/usr/share/glib-2.0/schemas/* /usr/share/glib-2.0/schemas/.
+glib-compile-schemas /usr/share/glib-2.0/schemas/
+EOT
+
+ENTRYPOINT ["/opt/hhg-studio/squashfs-root/bin/desktop-launch", "/opt/hhg-studio/squashfs-root/usr/local/bin/hhg-studio"]
+

--- a/applications/hhg-studio/Makefile
+++ b/applications/hhg-studio/Makefile
@@ -1,0 +1,11 @@
+.PHONY: all image sif clean
+
+all: sif
+
+image:
+	podman build -t hhg-studio:latest .
+
+sif: image
+	podman save hhg-studio:latest -o /tmp/hhg-studio.tar
+	singularity build hhg-studio.sif docker-archive:///tmp/hhg-studio.tar
+

--- a/applications/hhg-studio/Modulefile
+++ b/applications/hhg-studio/Modulefile
@@ -1,0 +1,13 @@
+#%Module1.0
+
+proc ModulesHelp { } {
+    puts stderr "Loads environment to run hhg-studio (via Singularity)."
+}
+
+module-whatis "Provides the 'hhg-studio' command which runs a Singularity image"
+
+# See https://wiki.tcl-lang.org/page/file+normalize
+set moddir [file dirname [file dirname [file normalize $ModulesCurrentModulefile/___]]]
+set sif_path [file normalize [file join $moddir "hhg-studio.sif"]]
+
+set-alias hhg-studio "singularity run $sif_path"

--- a/modules/hhg-studio
+++ b/modules/hhg-studio
@@ -1,0 +1,1 @@
+../applications/hhg-studio/Modulefile


### PR DESCRIPTION
Adds hhg-studio as an application using a singularity container file.

Done this way because hhg-studio is only distributed via snap (no source is provided), and the snap relies on a newer version of glibc than what is on maxwell/el9 so we can't just extract it and run.

The dockerfile uses an ubuntu base to download and extract the snap, separate stage copies this and includes the required runtime dependencies.

The modulefile adds an alias command for `hhg-studio` which runs the singularity image.